### PR TITLE
Show only approved records on view health history page

### DIFF
--- a/healthScore/user_utils.py
+++ b/healthScore/user_utils.py
@@ -48,6 +48,11 @@ def get_health_history_details(request):
             ).values_list("id", flat=True)
             history_list = history_list.filter(hospitalID__in=hospital_ids)
 
+        # Filter records by status
+        record_status = request.GET.get("record_status")
+        if record_status:
+            history_list = history_list.filter(status=record_status)
+
         detailed_history_list = []
         each_details = []
         for h in history_list:

--- a/healthScore/views.py
+++ b/healthScore/views.py
@@ -47,6 +47,13 @@ def test_default_values(request):
 
 
 def view_health_history(request):
+    # Create a new QueryDict object with the desired parameters
+    updated_params = request.GET.copy()
+    updated_params["record_status"] = "approved"
+
+    # Update request.GET with the modified QueryDict
+    request.GET = updated_params
+
     zipped_details = get_health_history_details(request=request)
     return render(request, "view_history.html", {"zipped_details": zipped_details})
 

--- a/healthScore/views.py
+++ b/healthScore/views.py
@@ -47,7 +47,7 @@ def test_default_values(request):
 
 
 def view_health_history(request):
-    # Create a new QueryDict object with the desired parameters
+    # Create a new QueryDict object with the desired parameters: fetch only approved records for health history page
     updated_params = request.GET.copy()
     updated_params["record_status"] = "approved"
 


### PR DESCRIPTION
## Description
- We plan of showing only the **approved** records on health history page
- The **pending** and **rejected** records will show as requests on the health history requests page
- Also added a filtering condition in **get_health_history_details** to filter records based on status

## How did you test the changes?
- Tested the changes by checking the response of backend API call on view health history page
- It displayed only the approved records after updating the DB values

## Testing Screenshots (Optional)
<img width="1440" alt="image" src="https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/assets/83601608/91a729e7-5459-4d24-ae6b-86070ab2579f">
