### PR TITLE
Add csrf exempt token for registration call

### DIFF
--- a/healthScore/views.py
+++ b/healthScore/views.py
@@ -310,6 +310,7 @@ def view_report(request):
         return response
 
 
+@csrf_exempt
 def registration(request):
     if request.method == "POST":
         role = request.POST.get("role")


### PR DESCRIPTION
## Description
- Getting `CSRF token missing` error when I try to register a healthcare admin on the website

## How did you test the changes?
- Was testing the registration call on integration instance

## Testing Screenshots (Optional)

<img width="1440" alt="image" src="https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/assets/83601608/f0ffb56c-3bf0-45ee-91a3-2bd223bab48c">
