### PR TITLE
Healthcare admin & workers editing their profiles

### DIFF
--- a/healthScore/templates/header.html
+++ b/healthScore/templates/header.html
@@ -108,6 +108,7 @@
                     <li><a href="#" class="nav-link">Dashboard</a></li>
                     <li><a href="#" class="nav-link">Patients</a></li>
                     <li><a href="#" class="nav-link">Schedule</a></li>
+                    <li><a href="/hs/userInfo" class="nav-link">Profile</a></li>
                 </ul>
                 
                 <!-- Staff Member Navigation -->

--- a/healthScore/templates/user_profile.html
+++ b/healthScore/templates/user_profile.html
@@ -74,12 +74,10 @@
                 <label for="userPhone">Phone Number</label>
                 <input type="text" class="form-control custom-width" id="userPhone" name="contactInfo" value="{{ userInfo.contactInfo }}">
             </div>
-          <!--
-          <div class="form-group">
-            <label for="userProfilePicture">Profile Picture</label>
-            <input type="file" class="form-control-file" id="userProfilePicture" name="profile_picture">
-          </div>
-          -->
+            <div class="form-group">
+                <label for="userProfilePicture">Profile Picture</label>
+                <input type="file" class="form-control-file" id="userProfilePicture" name="profile_picture">
+            </div>
         {% elif user.is_authenticated and user.is_healthcare_worker %}
             <div id="formFeedback" class="mb-3"></div>
             <div class="form-group">
@@ -97,6 +95,10 @@
             <div class="form-group">
                 <label for="workerDepartment">Department</label>
                 <input type="text" class="form-control custom-width" id="workerDepartment" name="specialization" value="{{ userInfo.specialization }}">
+            </div>
+            <div class="form-group">
+                <label for="workerProfilePicture">Profile Picture</label>
+                <input type="file" class="form-control-file" id="workerProfilePicture" name="profile_picture">
             </div>
         
         {% elif user.is_authenticated and user.is_staff %}
@@ -116,6 +118,10 @@
             <div class="form-group">
                 <label for="adminDepartment">Department</label>
                 <input type="text" class="form-control custom-width" id="adminDepartment" name="specialization" value="{{ userInfo.specialization }}">
+            </div>
+            <div class="form-group">
+                <label for="adminProfilePicture">Profile Picture</label>
+                <input type="file" class="form-control-file" id="adminProfilePicture" name="profile_picture">
             </div>
           
         {% endif %}

--- a/healthScore/templates/user_profile.html
+++ b/healthScore/templates/user_profile.html
@@ -6,15 +6,19 @@
 <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
 <style>
     .list-group-item-action.active {
-        background-color: #9D76C1;
-        border-color: lightgray;
+        background-color: #5B0888 !important;
+        border-color: lightgray !important;
     }
     .custom-save-btn {
-        background-color: #9D76C1;
+        background-color: #5B0888;
+        border-color: transparent;
         color: white;
+        padding: 8px 15px;
+        border-radius: 5px;
+        cursor: pointer;
     }
     .custom-save-btn:hover {
-        background-color: #7749A2;
+        background-color: #2d0444;
         color: white;
     }
     .profile-pic {
@@ -52,34 +56,73 @@
     <div class="col-md-9 ml-sm-auto col-lg-10 px-md-4 py-4">
       <form id="editUserForm">
         <h4>Account Details</h4>
-          
-          <div id="formFeedback" class="mb-3"></div>
-        <div class="form-group">
-          <label for="userName">Name</label>
-          <input type="text" class="form-control custom-width" id="userName" name="name" value="{{ userInfo.name }}">
-        </div>
-        <div class="form-group">
-          <label for="userEmail">Email address</label>
-          <input type="email" class="form-control custom-width" id="userEmail" name="email" value="{{ userInfo.email }}">
-        </div>
-        <div class="form-group">
-          <label for="userAddress">Address</label>
-          <input type="text" class="form-control custom-width" id="userAddress" name="address" value="{{ userInfo.address }}">
-        </div>
-        <div class="form-group">
-          <label for="userPhone">Phone Number</label>
-          <input type="text" class="form-control custom-width" id="userPhone" name="contactInfo" value="{{ userInfo.contactInfo }}">
-        </div>
+          {% if user.is_authenticated and user.is_patient %}
+            <div id="formFeedback" class="mb-3"></div>
+            <div class="form-group">
+                <label for="userName">Name</label>
+                <input type="text" class="form-control custom-width" id="userName" name="name" value="{{ userInfo.name }}">
+            </div>
+            <div class="form-group">
+                <label for="userEmail">Email address</label>
+                <input type="email" class="form-control custom-width" id="userEmail" name="email" value="{{ userInfo.email }}">
+            </div>
+            <div class="form-group">
+                <label for="userAddress">Address</label>
+                <input type="text" class="form-control custom-width" id="userAddress" name="address" value="{{ userInfo.address }}">
+            </div>
+            <div class="form-group">
+                <label for="userPhone">Phone Number</label>
+                <input type="text" class="form-control custom-width" id="userPhone" name="contactInfo" value="{{ userInfo.contactInfo }}">
+            </div>
           <!--
           <div class="form-group">
             <label for="userProfilePicture">Profile Picture</label>
             <input type="file" class="form-control-file" id="userProfilePicture" name="profile_picture">
           </div>
           -->
-          
-          {% csrf_token %}
+        {% elif user.is_authenticated and user.is_healthcare_worker %}
+            <div id="formFeedback" class="mb-3"></div>
+            <div class="form-group">
+                <label for="workerUserName">Name</label>
+                <input type="text" class="form-control custom-width" id="workerUserName" name="name" value="{{ userInfo.name }}">
+            </div>
+            <div class="form-group">
+                <label for="workerUserEmail">Email address</label>
+                <input type="email" class="form-control custom-width" id="workerUserEmail" name="email" value="{{ userInfo.email }}">
+            </div>
+            <div class="form-group">
+                <label for="workerUserPhone">Phone Number</label>
+                <input type="text" class="form-control custom-width" id="workerUserPhone" name="contactInfo" value="{{ userInfo.contactInfo }}">
+            </div>
+            <div class="form-group">
+                <label for="workerDepartment">Department</label>
+                <input type="text" class="form-control custom-width" id="workerDepartment" name="specialization" value="{{ userInfo.specialization }}">
+            </div>
         
-        <button type="button" class="btn custom-save-btn" onclick="submitEditForm()">Save Changes</button>
+        {% elif user.is_authenticated and user.is_staff %}
+            <div id="formFeedback" class="mb-3"></div>
+            <div class="form-group">
+                <label for="adminName">Name</label>
+                <input type="text" class="form-control custom-width" id="adminName" name="name" value="{{ userInfo.name }}">
+            </div>
+            <div class="form-group">
+                <label for="adminEmail">Email address</label>
+                <input type="email" class="form-control custom-width" id="adminEmail" name="email" value="{{ userInfo.email }}">
+            </div>
+            <div class="form-group">
+                <label for="adminPhone">Phone Number</label>
+                <input type="text" class="form-control custom-width" id="adminPhone" name="contactInfo" value="{{ userInfo.contactInfo }}">
+            </div>
+            <div class="form-group">
+                <label for="adminDepartment">Department</label>
+                <input type="text" class="form-control custom-width" id="adminDepartment" name="specialization" value="{{ userInfo.specialization }}">
+            </div>
+          
+        {% endif %}
+          
+      {% csrf_token %}
+        
+        <button type="button" class="custom-save-btn" onclick="submitEditForm()">Save Changes</button>
           
       </form>
     </div>

--- a/healthScore/views.py
+++ b/healthScore/views.py
@@ -133,6 +133,13 @@ def view_user_info(request):
             "bloodGroup": current_user.bloodGroup,
             "requests": json.dumps(current_user.requests),
         }
+
+        try:
+            hospital_staff = HospitalStaff.objects.get(userID=current_user.id)
+            userInfo['specialization'] = hospital_staff.specialization
+        except HospitalStaff.DoesNotExist:
+            userInfo['specialization'] = 'None'
+
         return render(request, "user_profile.html", {"userInfo": userInfo})
 
 
@@ -165,6 +172,17 @@ def edit_user_info(request):
             if new_value and new_value != current_value:
                 setattr(current_user, field, new_value)
                 data_updated = True
+
+        new_specialization = updatedData.get("specialization")
+        if new_specialization:
+            try:
+                hospital_staff = HospitalStaff.objects.get(userID=current_user.id)
+                if hospital_staff.specialization != new_specialization:
+                    hospital_staff.specialization = new_specialization
+                    hospital_staff.save()
+                    data_updated = True
+            except HospitalStaff.DoesNotExist:
+                pass
 
         if data_updated:
             current_user.save()

--- a/healthScore/views.py
+++ b/healthScore/views.py
@@ -136,9 +136,9 @@ def view_user_info(request):
 
         try:
             hospital_staff = HospitalStaff.objects.get(userID=current_user.id)
-            userInfo['specialization'] = hospital_staff.specialization
+            userInfo["specialization"] = hospital_staff.specialization
         except HospitalStaff.DoesNotExist:
-            userInfo['specialization'] = 'None'
+            userInfo["specialization"] = "None"
 
         return render(request, "user_profile.html", {"userInfo": userInfo})
 


### PR DESCRIPTION
## Description
Changed the edit profile page for different user types. Admins and healthcare workers can now update name, phone number, email and department. Added in a section for update profile pictures, which will get integrated with the updates Shreyas is making.

## How did you test the changes?
Tested out different user profiles and confirmed changes were flowing through to the database.

## Testing Screenshots (Optional)
<img width="1413" alt="Screenshot 2024-03-29 at 9 46 26 PM" src="https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/assets/22528898/6bcb70a7-e501-4e35-bb2a-2be34bb99b58">
<img width="1412" alt="Screenshot 2024-03-29 at 9 47 19 PM" src="https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/assets/22528898/58dabf19-3121-4578-bfec-8c6181505d5a">
