### PR TITLE
Add PUT call for updating status of health history access request

### DIFF
--- a/healthScore/urls.py
+++ b/healthScore/urls.py
@@ -84,4 +84,9 @@ urlpatterns = [
         views.view_health_history_access_requests,
         name="view_health_history_access_requests",
     ),
+    path(
+        "updateHealthHistoryAccessRequestStatus",
+        views.update_health_history_access_request_status,
+        name="update_health_history_access_request_status",
+    ),
 ]

--- a/healthScore/views.py
+++ b/healthScore/views.py
@@ -793,3 +793,22 @@ def view_health_history_access_requests(request):
         )
 
     return JsonResponse({"error": "wrong access method"}, status=401)
+
+
+@login_required
+@csrf_exempt
+def update_health_history_access_request_status(request):
+    if request.user.is_authenticated and request.method == "PUT":
+        updatedData = json.loads(request.body)
+        request_id = updatedData.get("request_id")
+        status = updatedData.get("status")
+
+        request = get_object_or_404(HealthHistoryAccessRequest, id=request_id)
+
+        request.status = status
+        request.save()
+        return JsonResponse(
+            {"message": "Request status updated successfully"}, status=200
+        )
+
+    return JsonResponse({"error": "Unauthorized"}, status=401)

--- a/healthScore/views.py
+++ b/healthScore/views.py
@@ -777,7 +777,7 @@ def request_health_history(request):
 
         return redirect("homepage")
 
-    return JsonResponse({"error": "Unauthorized"}, status=401)
+    return render(request, "request_health_history.html")
 
 
 @login_required


### PR DESCRIPTION
## Description
- Added **update_health_history_access_request_status** function to update status of health history access requests by healthcare workers/3rd party institutions
- Added unit test cases for the same
- Fix unauthorized error on request health history page

## How did you test the changes?
- Tested the API call via postman

## Testing Screenshots (Optional)
![image](https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/assets/83601608/3e877db4-eb4a-48f8-b116-d754ac94cb2f)

![image](https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/assets/83601608/0c1c6014-3ada-43c3-8425-9de5c6c8a4f0)

<img width="1440" alt="image" src="https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/assets/83601608/6333f3f2-16df-4cfb-8fd0-4c07744afa08">
