### PR TITLE
Send email when an access request is approved or rejected

### DIFF
--- a/healthScore/tests.py
+++ b/healthScore/tests.py
@@ -889,6 +889,17 @@ class UpdateHealthHistoryAccessRequestStatusTestCase(TestCase):
         response = update_health_history_access_request_status(request)
         self.assertEqual(response.status_code, 200)
 
+    def test_reject_request(self):
+        request = self.factory.put(
+            reverse("update_health_history_access_request_status"),
+            data={"request_id": 1, "status": "rejected"},
+            content_type="application/json",
+        )
+
+        request.user = self.user
+        response = update_health_history_access_request_status(request)
+        self.assertEqual(response.status_code, 200)
+
     def test_unauthorized_error(self):
         request = self.factory.post(
             reverse("update_health_history_access_request_status"),

--- a/healthScore/tests.py
+++ b/healthScore/tests.py
@@ -877,6 +877,14 @@ class UpdateHealthHistoryAccessRequestStatusTestCase(TestCase):
             purpose="For medical clearances",
             userID=self.user,
         )
+        HealthHistoryAccessRequest.objects.create(
+            id=2,
+            status="pending",
+            requestorName="NYU",
+            requestorEmail="",
+            purpose="For medical clearances",
+            userID=self.user,
+        )
 
     def test_approve_request(self):
         request = self.factory.put(
@@ -899,6 +907,36 @@ class UpdateHealthHistoryAccessRequestStatusTestCase(TestCase):
         request.user = self.user
         response = update_health_history_access_request_status(request)
         self.assertEqual(response.status_code, 200)
+
+    def test_email_sent(self):
+        request = self.factory.put(
+            reverse("update_health_history_access_request_status"),
+            data={"request_id": 1, "status": "approved"},
+            content_type="application/json",
+        )
+
+        request.user = self.user
+        response = update_health_history_access_request_status(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "Email sent and request status updated successfully",
+            response.content.decode(),
+        )
+
+    def test_email_not_sent(self):
+        request = self.factory.put(
+            reverse("update_health_history_access_request_status"),
+            data={"request_id": 2, "status": "rejected"},
+            content_type="application/json",
+        )
+
+        request.user = self.user
+        response = update_health_history_access_request_status(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "Email could not be sent, but request status updated successfully",
+            response.content.decode(),
+        )
 
     def test_unauthorized_error(self):
         request = self.factory.post(

--- a/healthScore/views.py
+++ b/healthScore/views.py
@@ -37,6 +37,7 @@ from .models import (
 from .user_utils import get_health_history_details
 from .forms import PostForm, CommentForm
 from .file_upload import file_upload
+from django.core.mail import send_mail
 
 
 DATE_FORMAT = "%Y-%m-%d"
@@ -885,11 +886,28 @@ def update_health_history_access_request_status(request):
         updatedData = json.loads(request.body)
         request_id = updatedData.get("request_id")
         status = updatedData.get("status")
+        user_info = request.user
 
         request = get_object_or_404(HealthHistoryAccessRequest, id=request_id)
 
         request.status = status
         request.save()
+
+        if status == "approved":
+            send_mail(
+                f"Update on Health History Access of: {user_info.name}",
+                f"Hi {request.requestorName},\n\nYour request to access health history of {user_info.name} has been approved. Please find PDF report attached.\n\nRegards,\nHealth Score Team",
+                "from@example.com",
+                [request.requestorEmail],
+            )
+        else:
+            send_mail(
+                f"Update on Health History Access of: {user_info.name}",
+                f"Hi {request.requestorName},\n\nYour request to access health history of {user_info.name} has been rejected.\n\nRegards,\nHealth Score Team",
+                "from@example.com",
+                [request.requestorEmail],
+            )
+
         return JsonResponse(
             {"message": "Request status updated successfully"}, status=200
         )

--- a/healthScore/views.py
+++ b/healthScore/views.py
@@ -893,23 +893,31 @@ def update_health_history_access_request_status(request):
         request.status = status
         request.save()
 
+        send_mail_response = 0
+
         if status == "approved":
-            send_mail(
+            send_mail_response = send_mail(
                 f"Update on Health History Access of: {user_info.name}",
                 f"Hi {request.requestorName},\n\nYour request to access health history of {user_info.name} has been approved. Please find PDF report attached.\n\nRegards,\nHealth Score Team",
                 "from@example.com",
                 [request.requestorEmail],
             )
         else:
-            send_mail(
+            send_mail_response = send_mail(
                 f"Update on Health History Access of: {user_info.name}",
                 f"Hi {request.requestorName},\n\nYour request to access health history of {user_info.name} has been rejected.\n\nRegards,\nHealth Score Team",
                 "from@example.com",
                 [request.requestorEmail],
             )
 
-        return JsonResponse(
-            {"message": "Request status updated successfully"}, status=200
-        )
+        message_response = ""
+        if send_mail_response:
+            message_response = "Email sent and request status updated successfully"
+        else:
+            message_response = (
+                "Email could not be sent, but request status updated successfully"
+            )
+
+        return JsonResponse({"message": message_response}, status=200)
 
     return JsonResponse({"error": "Unauthorized"}, status=401)


### PR DESCRIPTION
## Description
- An email should be triggered when an access request is approved or rejected
- Added unit test cases

## How did you test the changes?
- Tested locally by making API calls from POSTMAN

## Testing Screenshots (Optional)
<img width="1103" alt="image" src="https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/assets/83601608/8158d0df-91e0-4196-987f-31d75de58c25">
