### PR TITLE
Fix Issue 210

### DIFF
--- a/healthScore/community_data.py
+++ b/healthScore/community_data.py
@@ -101,7 +101,8 @@ def create_comments(request, post_id):
 
 @login_required(login_url="/")
 def delete_comment(request, comment_id):
-    comment = get_object_or_404(Comment, id=comment_id)
+    userID = request.user.id
+    comment = get_object_or_404(Comment, id=comment_id, commenter=userID)
     if request.method == "GET":
         comment.delete()
 

--- a/healthScore/community_data.py
+++ b/healthScore/community_data.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse
 
 from .models import (
     Post,
@@ -102,7 +103,11 @@ def create_comments(request, post_id):
 @login_required(login_url="/")
 def delete_comment(request, comment_id):
     userID = request.user.id
-    comment = get_object_or_404(Comment, id=comment_id, commenter=userID)
+    comment = get_object_or_404(Comment, id=comment_id)
+
+    if comment.post.user.id != userID and comment.commenter.id != userID:
+        return JsonResponse({"error": "Unauthorized"}, status=401)
+
     if request.method == "GET":
         comment.delete()
 


### PR DESCRIPTION
## Description
- https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/issues/210
- For deleting other's comments, the user should be creator of the post

## How did you test the changes?
Tested the following cases locally -
- Users should be able to delete their personal comments
- Creators of a post should be able to delete any comment
- People who did not write that post should not be able to delete comments posted by others

## Testing Screenshots (Optional)
<img width="1440" alt="image" src="https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/assets/83601608/ffff471d-5bae-4841-ac01-41570900c46e">
