### PR TITLE
Fix issue #203

### DIFF
--- a/healthScore/homepage_and_auth.py
+++ b/healthScore/homepage_and_auth.py
@@ -18,6 +18,7 @@ from .models import (
 )
 
 from .file_upload import file_upload
+from django.views.decorators.cache import never_cache
 
 
 def homepage(request):
@@ -92,7 +93,11 @@ def registration(request):
     return render(request, "registration.html")
 
 
+@never_cache
 def login_view(request):
+    if request.user.is_authenticated:
+        return redirect("user_dashboard")
+
     if request.method == "POST":
         email = request.POST.get("email")
         password = request.POST.get("password")


### PR DESCRIPTION
## Description
- If a user presses back button after successful login, or tries to access the login view, he/she will be redirected to the **user_dashboard** page
- By using the @never_cache decorator, we instruct Django not to cache the response of the **login_view** function, ensuring that the browser always makes a new request to the server when the login page is accessed
- https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-1/issues/203


## How did you test the changes?
Tested locally